### PR TITLE
[IMP] Ajout bouton et action server sur transaction + montant et état…

### DIFF
--- a/payment_payfip/data/cron_check_drafts.xml
+++ b/payment_payfip/data/cron_check_drafts.xml
@@ -6,7 +6,7 @@
             <field name="name">Cron to check PayFIP draft payment transactions</field>
             <field name="model_id" ref="payment.model_payment_transaction"/>
             <field name="state">code</field>
-            <field name="code">model.tipiregie_cron_check_draft_payment_transactions({'number_of_days':1,'send_summary':False})</field>
+            <field name="code">model.payfip_cron_check_draft_payment_transactions({'number_of_days':1,'send_summary':False})</field>
             <field name="active" eval="True"/>
             <field name="user_id" ref="base.user_root"/>
             <field name="interval_number">1</field>

--- a/payment_payfip/i18n/fr.po
+++ b/payment_payfip/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-02-17 15:12+0000\n"
-"PO-Revision-Date: 2020-02-17 15:12+0000\n"
+"POT-Creation-Date: 2020-10-13 09:48+0000\n"
+"PO-Revision-Date: 2020-10-13 09:48+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -83,9 +83,24 @@ msgid "<span><i>Fait,</i> votre paiement en ligne a été enregistré. Merci de 
 msgstr "<span><i>Fait,</i> votre paiement en ligne a été enregistré. Merci de votre commande.</span>"
 
 #. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Abandoned payment (A)"
+msgstr "Paiement abandonné (A)"
+
+#. module: payment_tipiregie
 #: model:ir.model.fields,field_description:payment_tipiregie.field_payment_acquirer_tipiregie_activation_mode
 msgid "Activation mode"
 msgstr "Mode activation"
+
+#. module: payment_tipiregie
+#: model:ir.ui.view,arch_db:payment_tipiregie.transaction_form_tipiregie
+msgid "Check PayFIP transaction"
+msgstr "Vérifier la transaction PayFIP"
+
+#. module: payment_tipiregie
+#: model:ir.actions.server,name:payment_tipiregie.tipiregie_check_transaction_action_server
+msgid "Check PayFIP transactions"
+msgstr "Vérifier les transactions PayFIP"
 
 #. module: payment_tipiregie
 #: model:ir.actions.server,name:payment_tipiregie.cron_check_draft_payment_transactions_ir_actions_server
@@ -98,6 +113,16 @@ msgstr "Cron pour vérifier les transactions de paiement PayFIP en brouillon"
 #: model:ir.model.fields,field_description:payment_tipiregie.field_payment_acquirer_tipiregie_customer_number
 msgid "Customer number"
 msgstr "Numéro client"
+
+#. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Effective payment (P)"
+msgstr "Paiement effectif (P)"
+
+#. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Effective payment (V)"
+msgstr "Paiement effectif (V)"
 
 #. module: payment_tipiregie
 #: model:ir.model.fields,field_description:payment_tipiregie.field_payment_acquirer_tipiregie_form_action_url
@@ -114,6 +139,16 @@ msgstr "Il semblerait que le numéro client n'est pas valide ou que le contrat P
 #: model:ir.model.fields,field_description:payment_tipiregie.field_payment_transaction_tipiregie_operation_identifier
 msgid "Operation identifier"
 msgstr "Identifiant d'opération"
+
+#. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Other cases (R)"
+msgstr "Autres cas (R)"
+
+#. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Other cases (Z)"
+msgstr "Autres cas (Z)"
 
 #. module: payment_tipiregie
 #: model:ir.ui.view,arch_db:payment_tipiregie.transaction_form_tipiregie
@@ -133,11 +168,27 @@ msgid "PayFIP: activation mode can be activate in test environment only and if t
 msgstr "PayFIP : l'activation ne peut être activée qu'en environement de test et si l'intermédiaire de paiement est publié sur le site web."
 
 #. module: payment_tipiregie
-#: code:addons/payment_tipiregie/models/inherited_payment_transaction.py:70
-#: code:addons/payment_tipiregie/models/inherited_payment_transaction.py:95
+#: code:addons/payment_tipiregie/models/inherited_payment_acquirer.py:63
+#, python-format
+msgid "PayFIP: activation mode can be activate in test environment only and if the payment acquirer is published on the website."
+msgstr "PayFIP : l'activation ne peut être activée qu'en environement de test et si l'intermédiaire de paiement est publié sur le site web."
+
+#. module: payment_tipiregie
+#: code:addons/payment_tipiregie/models/inherited_payment_transaction.py:94
+#: code:addons/payment_tipiregie/models/inherited_payment_transaction.py:119
 #, python-format
 msgid "PayFIP: received data with missing idop!"
 msgstr "PayFIP : données reçues mais idop manquant !"
+
+#. module: payment_tipiregie
+#: model:ir.model.fields,field_description:payment_tipiregie.field_payment_transaction_tipiregie_amount
+msgid "PayFIP amount"
+msgstr "Montant PayFIP"
+
+#. module: payment_tipiregie
+#: model:ir.model.fields,field_description:payment_tipiregie.field_payment_transaction_tipiregie_state
+msgid "PayFIP state"
+msgstr "État PayFIP"
 
 #. module: payment_tipiregie
 #: model:ir.model,name:payment_tipiregie.model_payment_acquirer
@@ -163,6 +214,11 @@ msgstr "URL de retour"
 #: model:ir.model.fields,field_description:payment_tipiregie.field_payment_transaction_tipiregie_sent_to_webservice
 msgid "Sent to PayFIP webservice"
 msgstr "Envoyée au service web de PayFIP"
+
+#. module: payment_tipiregie
+#: selection:payment.transaction,tipiregie_state:0
+msgid "Unknown"
+msgstr "Inconnu"
 
 #. module: payment_tipiregie
 #: model:payment.acquirer,pre_msg:payment_tipiregie.payment_acquirer_tipiregie

--- a/payment_payfip/views/payment_views.xml
+++ b/payment_payfip/views/payment_views.xml
@@ -37,17 +37,59 @@
         <field name="model">payment.transaction</field>
         <field name="inherit_id" ref="payment.transaction_form"/>
         <field name="arch" type="xml">
+            <!-- Add button to test transaction on acquirer site -->
+            <xpath expr="//header" position="inside">
+                <button name="action_payfip_check_transaction" type="object"
+                    class="oe_read_only"
+                    string="Check PayFIP transaction"
+                    attrs="{'invisible': ['|', ('state','not in',['draft','pending']), ('provider', '!=', 'payfip')]}"
+                    />
+            </xpath>
             <xpath expr='//sheet' position='inside'>
                 <notebook>
-                    <page name="payfip" string="PayFIP">
+                    <page name="payfip" string="PayFIP" attrs="{'invisible': [('provider', '!=', 'payfip')]}">
+                      <group>
                         <group>
                             <field name="payfip_operation_identifier"/>
                             <field name="payfip_sent_to_webservice"/>
                             <field name="payfip_return_url" invisible="1"/>
                         </group>
+                        <group>
+                            <field name="payfip_state"/>
+                            <field name="payfip_amount"/>
+                        </group>
+                      </group>
                     </page>
                 </notebook>
             </xpath>
         </field>
     </record>
+    <record id="transaction_list_payfip" model="ir.ui.view">
+        <field name="name">Add decorators for PayFIP transactions</field>
+        <field name="model">payment.transaction</field>
+        <field name="inherit_id" ref="payment.transaction_list"/>
+        <field name="arch" type="xml">
+            <!-- Add button to test transaction on acquirer site -->
+            <xpath expr="//tree" position="attributes">
+                <attribute name="decoration-muted">provider == 'payfip' and payfip_state == False</attribute>
+                <attribute name="decoration-danger">provider == 'payfip' and payfip_state != False and payfip_amount != amount</attribute>
+            </xpath>
+            <xpath expr="//tree" position="inside">
+                <field name="provider" invisible="1"/>
+                <field name="payfip_state" invisible="1"/>
+                <field name="payfip_amount" invisible="1"/>
+            </xpath>
+        </field>
+    </record>
+    <record id="payfip_check_transaction_action_server" model="ir.actions.server">
+        <field name="name">Check PayFIP transactions</field>
+        <field name="model_id" ref="model_payment_transaction"/>
+        <field name="binding_model_id" ref="model_payment_transaction"/>
+        <field name="state">code</field>
+        <field name="code">
+if records:
+    records._payfip_check_transactions()
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
… chez PayFIP

- Ajout des champs montant et état PayFIP sur la transaction (et vue form onglet PayFIP)
- Bouton sur vue form
- Action server multi sur vue tree
- Décoration DANGER sur vue tree si le montant est différent chez PayFIP

Le bouton et l'action server appelent les fonctions existantes tipiregie_get_result_from_web_service et _tipiregie_evaluate_data. La fonction _tipiregie_evaluate_data a été modifiée pour renseigner les nouveaux champs.