### PR TITLE
[Fix #22] Reduce interval between two call of cron "check_draft_payment_transaction"

### DIFF
--- a/payment_payfip/__manifest__.py
+++ b/payment_payfip/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': "Intermédiaire de paiement PayFIP",
-    'version': '11.0.1.0.1',
+    'version': '11.0.22.02.25',
     'summary': """Intermédiaire de paiement : Implémentation de PayFIP""",
     'author': "Horanet",
     'website': "http://www.horanet.com/",

--- a/payment_payfip/data/cron_check_drafts.xml
+++ b/payment_payfip/data/cron_check_drafts.xml
@@ -9,8 +9,8 @@
             <field name="code">model.payfip_cron_check_draft_payment_transactions({'number_of_days':1,'send_summary':False})</field>
             <field name="active" eval="True"/>
             <field name="user_id" ref="base.user_root"/>
-            <field name="interval_number">1</field>
-            <field name="interval_type">days</field>
+            <field name="interval_number">5</field>
+            <field name="interval_type">minutes</field>
             <field name="numbercall">-1</field>
             <field name="nextcall"
                    eval="(datetime.today()+timedelta(days=1)).replace(hour=2,minute=0,second=0).strftime('%Y-%m-%d %H:%M:%S')"/>

--- a/payment_payfip/migrations/11.0.22.02.25/post-migration-reduce-cron-interval.py
+++ b/payment_payfip/migrations/11.0.22.02.25/post-migration-reduce-cron-interval.py
@@ -1,0 +1,19 @@
+import logging
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    """Reduce interval of already existing cron (which are in no update mode)."""
+    if not version:
+        return
+
+    cron = env.ref('payment_payfip.cron_check_draft_payment_transactions', raise_if_not_found=False)
+    if cron and cron.interval_number == 1 and cron.interval_type == 'days':
+        cron.write({
+            'interval_number': 5,
+            'interval_type': 'minutes',
+        })
+        _logger.info("Reduce the cron_check_draft_payment_transactions interval from every day to every 5 minutes")

--- a/payment_payfip/models/inherited_payment_acquirer.py
+++ b/payment_payfip/models/inherited_payment_acquirer.py
@@ -83,7 +83,7 @@ class PayFIPAcquirer(models.Model):
     # region Model methods
     @api.model
     def _get_soap_url(self):
-        return "https://www.tipi.budget.gouv.fr/tpa/services/securite"
+        return "https://www.payfip.gouv.fr/tpa/services/securite"
 
     @api.model
     def _get_soap_namespaces(self):


### PR DESCRIPTION
It make more sens to check every few minutes the paiements whose answer are unknow, in case of succesfull feedback it can send the user's tickets sooner.

Taking advantage of this issue to change soap url of the new payfip url (from [www.tipi.budget](http://www.tipi.budget/) to [www.payfip](http://www.payfip/).)

Closes [#22]