### PR TITLE
Fix - Changement de l'URL d'envoi SOAP

### DIFF
--- a/payment_tipiregie/__manifest__.py
+++ b/payment_tipiregie/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': "Intermédiaire de paiement Tipi Régie",
-    'version': '10.0.1.3.2',
+    'version': '10.0.22.06.28',
     'summary': """Intermédiaire de paiement : Implémentation de Tipi Régie""",
     'description': "no warning",
     'author': "Horanet",

--- a/payment_tipiregie/data/payment_acquirer.xml
+++ b/payment_tipiregie/data/payment_acquirer.xml
@@ -12,7 +12,7 @@
                 <![CDATA[<p>You will be redirected to the Tipi website after clicking on the payment button.</p>]]>
             </field>
             <field name="tipiregie_customer_number">dummy</field>
-            <field name="tipiregie_form_action_url">https://www.tipi.budget.gouv.fr/tpa/paiementws.web</field>
+            <field name="tipiregie_form_action_url">https://www.payfip.gouv.fr/tpa/paiementws.web</field>
             <field name="description" type="html">
                 <p>Tipi Régie est un système de paiement en ligne français proposé pa la Direction générale des Finances
                     Publiques. Son but est de faciliter le paiement des services publics locaux.

--- a/payment_tipiregie/models/inherited_payment_acquirer.py
+++ b/payment_tipiregie/models/inherited_payment_acquirer.py
@@ -76,7 +76,7 @@ class TipiRegieAcquirer(models.Model):
     # region Model methods
     @api.model
     def _get_soap_url(self):
-        return "https://www.tipi.budget.gouv.fr/tpa/services/securite"
+        return "https://www.payfip.gouv.fr/tpa/services/securite"
 
     @api.model
     def _get_soap_namespaces(self):

--- a/payment_tipiregie/static/description/index.html
+++ b/payment_tipiregie/static/description/index.html
@@ -5,6 +5,25 @@
     </div>
 
     <h3 class="oe_slogan" style="text-align: left; border-bottom: 1px solid #eee; opacity: 1;">Description</h3>
+    <p class="alert alert-warning" role="alert"> Edit du 28 Juin 2022 : modification de l'url d'envoi SOAP de
+        https://www.tipi.budget.gouv.fr/ vers https://www.payfip.gouv.fr/.
+        Ce correctif est déjà appliqué en V11 dans le module migré PayFiP, un ajustement à dû être fait en v10 pour
+        toujours permettre aux clients d'utiliser cet intermédiaire. Cette modification n'empêchera pas une
+        migration en 11.
+    </p>
+
+    <details style="border: 1px solid #aaa; border-radius: 4px; padding: .5em .5em 0;">
+        <summary style="font-weight: bold; margin: -.5em -.5em 0; padding: .5em;">Extrait du mail de Payfip</summary>
+        Les appels à PayFiP doivent être désormais effectués sur l'adresse www.payfip.gouv.fr et non plus sur
+        "www.tipi.budget.gouv.fr".
+        Cette modification s'accompagnait d'une période transitoire de coexistence des 2 noms de domaines pour une durée
+        d'un an.
+        Le délai de reroutage à partir de l'ancien nom de domaine (www.tipi-budget.gouv.fr) arrivera donc à son terme le
+        30 juin 2022.
+        A compter de cette date, les appels à PayFiP réalisés sur l'ancien nom de domaine ne pourront plus être pris en
+        compte.
+    </details>
+    <br />
     <p>Tipi Régie est un système de paiement en ligne proposé pa la Direction générale des Finances Publiques. Son but
         est de faciliter le paiement des services publics locaux.</p>
     <p>Ce module de paiement permet de payer les commandes et factures, générées par Odoo, via le système de paiement


### PR DESCRIPTION
- Suite au changement de tipi en payfip, l'url www.tipi.budget.gouv.fr est passé à www.payfip.gouv.fr.
  Pendant un an Payfip a assuré la rétro compatibilité de l'url en redirigeant l'ancienne vers la nouvelle.
  Seulement à compter du 30 Juin 2022 cette redirection ne se fera plus.
  Il était donc nécessaire de la modifier dans le code source pour l'appel SOAP,
  en sachant que cette modification n'entrainera aucune problématique lors de la migration en 11.