### PR TITLE
[11.0][Fix #25] Fixing validation date offset

### DIFF
--- a/payment_payfip/__manifest__.py
+++ b/payment_payfip/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': "Intermédiaire de paiement PayFIP",
-    'version': '11.0.22.02.25',
+    'version': '11.0.22.08.16',
     'summary': """Intermédiaire de paiement : Implémentation de PayFIP""",
     'author': "Horanet",
     'website': "http://www.horanet.com/",

--- a/payment_payfip/migrations/11.0.22.08.16/pre-french-tz-to-utc-payfip-transaction-date-.py
+++ b/payment_payfip/migrations/11.0.22.08.16/pre-french-tz-to-utc-payfip-transaction-date-.py
@@ -1,0 +1,36 @@
+import logging
+import pytz
+
+from openupgradelib import openupgrade
+
+from odoo import fields
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    """Migrate Payfip transaction confirmation date to UTC date instead of french timezone."""
+    # Payfip timezone
+    payfip_tz = pytz.timezone('Europe/Paris')
+    # Retreive all payfip transaction with a confirmation date
+    payfip_transactions = env['payment.transaction'].search([
+        ('acquirer_id.provider', '=', 'payfip'),
+        ('date_validate', '!=', False),
+    ])
+
+    _logger.info(f"Number of Payfip transaction to migrate : {len(payfip_transactions)}")
+    chunk_size = 100
+    # Chunk transactions for processing
+    payfip_transactions_chunked = [payfip_transactions[i:i + chunk_size] for i in range(0, len(payfip_transactions), chunk_size)]
+
+    for idx, payfip_transaction_chunk in enumerate(payfip_transactions_chunked, start=1):
+        _logger.info(f"Payfip transaction processing chunk : {idx}/{len(payfip_transactions_chunked)}")
+        for payfip_transaction in payfip_transaction_chunk:
+            # Validate date to datetime object
+            date_validate = fields.Datetime.from_string(payfip_transaction.date_validate)
+            # Localize datetime and transform into an UTC one
+            utc_date_validate = payfip_tz.localize(date_validate).astimezone(pytz.UTC)
+            # Set UTC value into datetime
+            payfip_transaction.date_validate = fields.Datetime.to_string(utc_date_validate)
+    _logger.info(f"Payfip transaction all chunks have been processed.")

--- a/payment_payfip/models/inherited_payment_transaction.py
+++ b/payment_payfip/models/inherited_payment_transaction.py
@@ -154,9 +154,10 @@ class PayFIPTransaction(models.Model):
                 minute = int(payfip_datetime[2:4])
                 payfip_tz = pytz.timezone('Europe/Paris')
                 td_minute = timedelta(minutes=1)
-                date_validate = fields.Datetime.to_string(
+                # localize validation datetime into utc datetime string format
+                date_validate = fields.Datetime.to_string(payfip_tz.localize(
                     datetime(year, month, day, hour=hour, minute=minute, tzinfo=payfip_tz) + td_minute
-                )
+                ).astimezone(pytz.UTC))
 
             self.write({
                 'state': 'done',


### PR DESCRIPTION
Actually, validation dates on transactions are stored in the French
timezone but in Odoo the timezone attended is UTC. A minor fix is needed
in the _payfip_evaluate_data method for passing the timezone into an UTC
one.

Signed-off-by: Logan Gonet <logan.gonet@horanet.com>