### PR TITLE
Update payment_payfip_templates.xml

### DIFF
--- a/payment_payfip/views/payment_payfip_templates.xml
+++ b/payment_payfip/views/payment_payfip_templates.xml
@@ -5,7 +5,7 @@
             <!-- idOp -->
             <input type="hidden" name="data_set" t-att-data-action-url="tx_url" data-remove-me=""/>
             <input type="hidden" name="reference" t-att-value="reference"/>
-            <input type="hidden" name="amount" t-att-value="amount"/>
+            <input type="hidden" name="amount" t-att-value="'%.2f' % amount"/>
             <input type="hidden" name="return_url" t-att-value="return_url"/>
         </div>
     </template>


### PR DESCRIPTION
Linked to this issue : https://github.com/Horanet/payment_payfip/issues/36

To avoid binary with too much numbers to be send, we truncate the "amount" to have only 2 decimals.