### PR TITLE
[Fix #36] Ensure exact two-decimal precision for transaction amount

### DIFF
--- a/payment_payfip/__manifest__.py
+++ b/payment_payfip/__manifest__.py
@@ -1,6 +1,6 @@
 {
     'name': "Intermédiaire de paiement PayFIP",
-    'version': '13.0.24.12.31',
+    'version': '13.0.25.11.06',
     'summary': """Intermédiaire de paiement : Implémentation de PayFIP""",
     'author': "Horanet",
     'website': "https://www.horanet.com/",

--- a/payment_payfip/views/payment_payfip_templates.xml
+++ b/payment_payfip/views/payment_payfip_templates.xml
@@ -5,7 +5,7 @@
             <!-- idOp -->
             <input type="hidden" name="data_set" t-att-data-action-url="tx_url" data-remove-me=""/>
             <input type="hidden" name="reference" t-att-value="reference"/>
-            <input type="hidden" name="amount" t-att-value="amount"/>
+            <input type="hidden" name="amount" t-att-value="'%.2f' % amount"/>
             <input type="hidden" name="return_url" t-att-value="return_url"/>
         </div>
     </template>


### PR DESCRIPTION
This commit fixes a critical float precision issue within the PayFip payment form submission, ensuring amounts are passed with exact two-decimal precision.

The issue occurred because certain amounts, particularly those calculated via multiplication (e.g., 380 cents * 0.01 = 3.80), would sometimes retain trailing binary precision in Python, resulting in values like `3.8000000000000003`.

This subtle difference caused the transaction couldn't be retreived, leading to be unable to pay on certain amounts.

The solution is to explicitly format the amount field in the form template using *`'%.2f' % amount`, which truncates the value to exactly two decimal places before submission.